### PR TITLE
Fix 21 real bugs across memory, robotics, skills, and vision modules

### DIFF
--- a/modules/memory/episodic_memory.py
+++ b/modules/memory/episodic_memory.py
@@ -1,4 +1,8 @@
-from modules.attention.concept_similarity_attention import ConceptSimilarityMemoryAttention
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from typing import Optional
+from modules.attention.concept_similarity_memory_attention import ConceptSimilarityMemoryAttention
 
 class EpisodicEmbeddingLayer(nn.Module):
     def __init__(self, input_dim: int, output_dim: int, compression_rate: float = 0.9):

--- a/modules/memory/fading_memory.py
+++ b/modules/memory/fading_memory.py
@@ -1,3 +1,9 @@
+import math
+
+import torch
+import torch.nn as nn
+
+
 class FadingMemorySystem(nn.Module):
     def __init__(self, hidden_dim: int, decay_rate: float):
         super().__init__()

--- a/modules/memory/hopfield.py
+++ b/modules/memory/hopfield.py
@@ -1,8 +1,13 @@
 # ===========================
 # Memory Components
 # ===========================
+import random
+from typing import List, Optional
 
-
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
 
 
 class SparseHopfieldNetwork:

--- a/modules/memory/memory_consolidator.py
+++ b/modules/memory/memory_consolidator.py
@@ -1,3 +1,7 @@
+import time
+from typing import Any, Dict, Tuple
+
+
 class MemoryConsolidator:
     """
     Handles memory consolidation during "sleep" phases.

--- a/modules/memory/oni_memory.py
+++ b/modules/memory/oni_memory.py
@@ -17,9 +17,9 @@ import math
 from memory.episodic_memory import EpisodicBuffer, EpisodicEmbeddingLayer
 from memory.fading_memory import FadingMemorySystem
 from memory.heuristic_manager import HeuristicManager
-from memory.hopfield import SparceHopfieldNetwork, ModernContinuousHopfieldNetwork
+from memory.hopfield import SparseHopfieldNetwork, ModernContinuousHopfieldNetwork
 from memory.mem_handler import MemoryInterferenceHandler
-from memory.memory_consolidator import MemoryCosolidator
+from memory.memory_consolidator import MemoryConsolidator
 from memory.semantic_memory import SemanticMemoryLayer, TextPatternFinder
 from memory.snapshot_memory import SnapshotMemorySystem
 from memory.spatial_memory import SpatialMemoryModule
@@ -36,18 +36,20 @@ class Memory:
         self.ltm_capacity = ltm_capacity
         self.working_memory = []  # Short-term working memory as a list
         self.semantic_memory = {}  # Store generalized knowledge
-        self.ltm = ltm  # Long-term memory list
+        self.ltm = []  # Long-term memory list
         self.ltm_summary = {}  # Summary or knowledge graph of LTM
-        self.episodic_memory_path = 'C:/Users/jonny/Documents/PATH/ONI/ltm/episodes/'
-        self.semantic_memory_path = os.path.join('C:/Users/jonny/Documents/PATH/ONI/ltm_path/', 'semantic_memory.json')
-        self.ltm_summary_path = os.path.join('C:/Users/jonny/Documents/PATH/ONI/ltm_path/', "ltm_data.json")
+        _ltm_base = os.path.join(os.path.dirname(__file__), '..', '..', 'ltm')
+        self.episodic_memory_path = os.path.join(_ltm_base, 'episodes')
+        self.semantic_memory_path = os.path.join(_ltm_base, 'semantic_memory.json')
+        self.ltm_summary_path = os.path.join(_ltm_base, 'ltm_data.json')
         self.load_long_term_memory()
         self.episodic_embeddings = {}  # To store episodic embeddings
         self.semantic_embeddings = {}  # To store semantic embeddings
         self.episodic_layer = EpisodicEmbeddingLayer(input_dim=8192, output_dim=8192)
         self.semantic_layer = SemanticMemoryLayer(input_dim=8192, output_dim=8192)
-        self.episodic_layer.to(device)  # Adjust device as needed
-        self.semantic_layer.to(device)  # Adjust device as needed
+        _device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.episodic_layer.to(_device)
+        self.semantic_layer.to(_device)
         
         # New memory components
         self.episodic_buffer = EpisodicBuffer(hidden_dim=896, buffer_size=working_memory_capacity)
@@ -59,11 +61,11 @@ class Memory:
         self.is_sleeping = False
         self.last_sleep_time = time.time()
         self.sleep_interval = 3600  # Default: consolidate every hour
-        self.fading = FadingMemorySystem()
-        self.snapshot = SnapshotMemory()
+        self.fading = FadingMemorySystem(hidden_dim=896, decay_rate=0.05)
+        self.snapshot = SnapshotMemorySystem(hidden_dim=896)
     def cleanup(self):
         """Release any held resources."""
-        self.memory.data.zero_()
+        self.working_memory.clear()
         torch.cuda.empty_cache()
         
     def update_context(self, key: str, value: str):

--- a/modules/memory/snapshot_memory.py
+++ b/modules/memory/snapshot_memory.py
@@ -1,3 +1,9 @@
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+
 class SnapshotMemorySystem(nn.Module):
     def __init__(self, hidden_dim: int, memory_size: int = 8192):
         super().__init__()

--- a/modules/memory/spatial_memory.py
+++ b/modules/memory/spatial_memory.py
@@ -1,3 +1,6 @@
+from typing import Dict, Optional, Tuple
+
+
 class SpatialMemoryModule:
     def __init__(self, room_size: Tuple[int, int], overlap: float = 0.2, max_memory: int = 100):
         """

--- a/modules/memory/volatile_memory.py
+++ b/modules/memory/volatile_memory.py
@@ -2,7 +2,7 @@ import redis
 import pickle
 
 class VolatileMemory:
-    def __init__(self, host='localhost', port=14807, db=MCCHC7P0):
+    def __init__(self, host='localhost', port=14807, db=0):
         self.client = redis.StrictRedis(host=host, port=port, db=db)
 
     def set(self, key, value, ttl=300):

--- a/modules/robotics/IOT_robot_controller.py
+++ b/modules/robotics/IOT_robot_controller.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 import time
 import platform
 
-from modules.decision import ExecutiveDecisionNet
+from modules.ExecutiveFunction.decision import ExecutiveDecisionNet
 
 class ParietalCortexEmulator(nn.Module):
     def __init__(self, tactile_dim: int, vision_dim: int, audio_dim: int, intent_dim: int, output_dim: int):
@@ -84,7 +84,7 @@ def issue_motor_command(motor_command: torch.Tensor, mode="pi"):
         import smbus
         bus = smbus.SMBus(1)
         address = 0x40  # example I2C address
-        data = [int(val * 255) for val in motor_command]
+        data = [max(0, min(255, int((val + 1) * 127.5))) for val in motor_command]
         bus.write_i2c_block_data(address, 0x00, data)
 
     else:

--- a/modules/skills/dynamic_module_injector.py
+++ b/modules/skills/dynamic_module_injector.py
@@ -1,12 +1,14 @@
+import io
+import inspect
+import os
+import struct
+from typing import Any, Dict, List, Tuple, Union
+
+import requests
 import torch
 import torch.nn as nn
 from transformers import AutoModel, AutoConfig
 import huggingface_hub
-import inspect
-from typing import Dict, Any, List, Union, Tuple
-import os
-import requests
-import struct
 
 class DynamicModuleInjector(nn.Module):
     def __init__(self):

--- a/modules/skills/oni_portscanner.py
+++ b/modules/skills/oni_portscanner.py
@@ -25,7 +25,7 @@ class PortScanner:
             thread.start()
 
 
-    def run():
+    def run(self):
         target = input("Enter the target IP address: ")
         start_port = int(input("Enter the starting port: "))
         end_port = int(input("Enter the ending port: "))

--- a/modules/vision/oni_vision.py
+++ b/modules/vision/oni_vision.py
@@ -228,9 +228,6 @@ class MiniVisionTransformer(nn.Module):
         else:
             raise IndexError("Pointer position is out of bounds.")
 
-# Example instantiation
-num_classes = 1000  # Example for image classification
-
 class MiniVisionTransformerWithIO(MiniVisionTransformer):
     def __init__(self, *args, **kwargs):
         super(MiniVisionTransformerWithIO, self).__init__(*args, **kwargs)
@@ -326,19 +323,15 @@ class MiniVisionTransformerWithIO(MiniVisionTransformer):
             print(f"Error in process_input: {e}")
             return None
 
-# Example Usage
-vision_system = MiniVisionTransformerWithIO(3, 64, 256, exec_func=None, num_transformer_layers=6, nhead=8, num_classes=1000)
+if __name__ == '__main__':
+    # Example Usage
+    vision_system = MiniVisionTransformerWithIO(3, 64, 256, exec_func=None, num_transformer_layers=6, nhead=8, num_classes=1000)
 
-# Process screen
-screen_output = vision_system.process_input(input_type='screen')
+    screen_output = vision_system.process_input(input_type='screen')
+    camera_output = vision_system.process_input(input_type='camera', camera_indices=[0])
+    multi_camera_output = vision_system.process_input(input_type='cameras', camera_indices=[0, 1])
 
-# Process single camera
-camera_output = vision_system.process_input(input_type='camera', camera_indices=[0])
-
-# Process multiple cameras
-multi_camera_output = vision_system.process_input(input_type='cameras', camera_indices=[0, 1])
-
-print(f"Screen Output: {screen_output}")
-print(f"Camera Output: {camera_output}")
-print(f"Multi-Camera Output: {multi_camera_output}")
+    print(f"Screen Output: {screen_output}")
+    print(f"Camera Output: {camera_output}")
+    print(f"Multi-Camera Output: {multi_camera_output}")
 


### PR DESCRIPTION
- volatile_memory: fix NameError (db=MCCHC7P0 → db=0)
- episodic_memory: fix wrong import path and add missing imports
- hopfield: add missing imports (numpy, random, torch, nn, typing)
- fading_memory: add missing imports (math, torch, nn)
- snapshot_memory: add missing imports (torch, nn, Optional)
- spatial_memory: add missing imports (Tuple, Dict, Optional)
- memory_consolidator: add missing imports (time, Dict, Any, Tuple)
- oni_memory: fix undefined ltm variable, undefined device, two typos in import names (SparceHopfield→Sparse, MemoryCosolidator→Consolidator), FadingMemorySystem/SnapshotMemorySystem missing required args and wrong class name, self.memory.data.zero_() on non-existent attr, hardcoded Windows paths replaced with relative os.path construction
- IOT_robot_controller: fix wrong import path for ExecutiveDecisionNet; fix I2C byte range (Tanh [-1,1] → scaled [0,255] to prevent ValueError)
- dynamic_module_injector: add missing `import io` (used in _try_load_model)
- oni_portscanner: add missing `self` param to PortScanner.run()
- oni_vision: guard module-level example code behind __main__ check to prevent screen capture and camera access on every import; remove stray num_classes = 1000 statement at module level

https://claude.ai/code/session_01WEEWKPAv69qaUpnhPtdce6