### PR TITLE
Add stochastic governor: Markov tree, Bayesian routing, MHC hyperconn…

### DIFF
--- a/ONI.py
+++ b/ONI.py
@@ -297,6 +297,7 @@ from modules.agents.micro_agent import MicroAgent
 from modules.planner.gru_planner import GRUPlanner
 from modules.memory.memory_ensemble import MemoryEnsemble
 from governor.firing_router import FiringRouter
+from governor.hyperconnection import HyperConnectionLayer
 
 try:
     from modules.attention.temporal_tri_attention import TemporalSparseTrifocusedAttention
@@ -494,6 +495,13 @@ class OniMicro(nn.Module):
             lm=self.nlp_module if hasattr(self.nlp_module, 'forward') else None,
         )
 
+        # HyperConnectionLayer — cross-module MHC residual hyperconnections
+        self.hyper_connections = HyperConnectionLayer(
+            module_names=["nlp", "vision", "audio"],
+            hidden_dim=hidden_dim,
+            num_heads=8,
+        )
+
     def add_tool(self, tool):
         self.toolregistry.register_tool(tool)
 
@@ -570,6 +578,28 @@ class OniMicro(nn.Module):
             audio_output, audio_energy = torch.zeros_like(x), 0.0  # Default if audio fails
 
         try:
+            # HyperConnection enrichment: each module attends to all others (MHC residual)
+            _h_nlp    = nlp_output.mean(1)    if nlp_output.dim()    == 3 else nlp_output
+            _h_vision = vision_output.mean(1) if vision_output.dim() == 3 else vision_output
+            _h_audio  = audio_output.mean(1)  if audio_output.dim()  == 3 else audio_output
+            _enriched = self.hyper_connections({
+                "nlp":    _h_nlp,
+                "vision": _h_vision,
+                "audio":  _h_audio,
+            })
+            # Unsqueeze back to seq dim if original was 3D
+            if nlp_output.dim() == 3:
+                nlp_output    = _enriched["nlp"].unsqueeze(1)
+                vision_output = _enriched["vision"].unsqueeze(1)
+                audio_output  = _enriched["audio"].unsqueeze(1)
+            else:
+                nlp_output    = _enriched["nlp"]
+                vision_output = _enriched["vision"]
+                audio_output  = _enriched["audio"]
+        except Exception as e:
+            print(f"Error in hyperconnection enrichment: {e}")
+
+        try:
             # Multi-modal attention
             attended_output = self.multi_modal_attention(nlp_output, vision_output, audio_output)
         except Exception as e:
@@ -598,6 +628,22 @@ class OniMicro(nn.Module):
         except Exception as e:
             print(f"Error in Meta-cognition module: {e}")
             meta_output, confidence, conflicts, meta_metadata = adjusted_output, 0.5, [], {}
+
+        try:
+            # Governor: stochastic firing router over the network state
+            # Uses meta_output as the routing signal; fires top-k paths
+            _gov_in = meta_output.mean(1) if meta_output.dim() == 3 else meta_output
+            _gov_out, _gate_weights, _fired = self.governor(
+                _gov_in, training=self.training
+            )
+            if meta_output.dim() == 3:
+                meta_output = _gov_out.unsqueeze(1)
+            else:
+                meta_output = _gov_out
+        except Exception as e:
+            print(f"Error in governor routing: {e}")
+            _gate_weights = None
+            _fired = []
 
         try:
             # Final output layer
@@ -1618,4 +1664,17 @@ class OniMicro(nn.Module):
             except Exception:
                 pass
         return outputs
-        return compressor
+
+    def observe_outcome(self, reward: float) -> None:
+        """
+        Push a scalar reward to the governor's Markov decision tree for live
+        policy adjusting.  Call this after evaluating the quality of the most
+        recent forward() or step() pass.
+
+        reward > 0 : successful outcome → biases future routing toward those paths
+        reward ≤ 0 : poor outcome       → biases future routing away from those paths
+        """
+        try:
+            self.governor.observe_outcome(reward)
+        except Exception as e:
+            print(f"Error in observe_outcome: {e}")

--- a/governor/firing_router.py
+++ b/governor/firing_router.py
@@ -1,33 +1,43 @@
 """
 governor/firing_router.py
 ==========================
-FiringRouter — the ONI Governor.
+StochasticFiringRouter — the ONI Governor.
 
-A multi-AI orthogonal network with a firing routing mechanism.
-Each 'path' is a named expert transform.  The router decides which paths fire
-for a given input, combines their outputs, and returns:
-  - combined output tensor
-  - gate weights (for diversity loss / logging)
-  - list of fired path names (for selective full-module invocation upstream)
+A multi-AI orthogonal network with a stochastic firing routing mechanism.
+Integrates:
+  MarkovDecisionTree  : past decision / outcome registry with Bayesian
+                        (Thompson Sampling) logit adjustment
+  Gumbel-Softmax      : differentiable stochastic path sampling during
+                        training; hard top-k at inference
+  Live policy update  : observe_outcome(reward) propagates reward back
+                        to the Markov tree without requiring gradients
 
 Design properties
 -----------------
-  Sparse activation  : only top-k paths fire per forward pass
-  Firing threshold   : paths below the threshold are suppressed entirely
-  Orthogonality loss : diversity_loss() encourages path specialisation
-  Residual blend     : learned α blends router output with passthrough
-  Differentiable     : soft routing during training, hard top-k at inference
+  Sparse activation   : only top-k paths fire per forward pass
+  Firing threshold    : paths below the threshold are suppressed entirely
+  Stochastic training : Gumbel noise → differentiable discrete choices
+  Bayesian priors     : Thompson Sampling biases routing toward
+                        historically successful paths for the current state
+  Orthogonality loss  : diversity_loss() encourages path specialisation
+  Residual blend      : learned α blends router output with passthrough
+  Live updating       : no gradient required — count-based Bayesian update
+
+Backward-compat alias
+  FiringRouter = StochasticFiringRouter
 """
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from governor.markov_tree import MarkovDecisionTree
+
 
 class PathGate(nn.Module):
-    """Compact gate: hidden_dim → n_paths firing probabilities."""
+    """Compact gate: hidden_dim → n_paths firing logits."""
 
     def __init__(self, hidden_dim: int, n_paths: int):
         super().__init__()
@@ -38,12 +48,13 @@ class PathGate(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return torch.softmax(self.proj(x), dim=-1)
+        """Returns raw logits (B, n_paths) — caller applies softmax/gumbel."""
+        return self.proj(x)
 
 
-class FiringRouter(nn.Module):
+class StochasticFiringRouter(nn.Module):
     """
-    Multi-AI orthogonal network router (ONI Governor).
+    Multi-AI orthogonal network router (ONI Governor) — stochastic variant.
 
     Parameters
     ----------
@@ -52,11 +63,16 @@ class FiringRouter(nn.Module):
                         (B, hidden_dim) and return (B, hidden_dim)
     top_k             : maximum number of paths that can fire simultaneously
     firing_threshold  : minimum gate probability for a path to fire
+    gumbel_tau        : initial Gumbel-Softmax temperature (anneals toward 0)
+    tau_min           : minimum temperature floor
+    markov_lsh_dim    : LSH dimension for MarkovDecisionTree state hashing
+    markov_capacity   : capacity of the Markov registry
+    markov_history    : rolling window length for live updating
 
     Forward returns
     ---------------
     output      : (B, hidden_dim) — weighted sum of fired paths + residual
-    gate_weights: (B, n_paths)   — soft routing probabilities
+    gate_weights: (B, n_paths)   — routing probabilities (soft or hard)
     fired_names : List[str]      — names of paths that fired this step
     """
 
@@ -66,16 +82,24 @@ class FiringRouter(nn.Module):
         paths: Dict[str, nn.Module],
         top_k: int = 2,
         firing_threshold: float = 0.1,
+        gumbel_tau: float = 1.0,
+        tau_min: float = 0.1,
+        markov_lsh_dim: int = 64,
+        markov_capacity: int = 8192,
+        markov_history: int = 128,
     ):
         super().__init__()
         self.hidden_dim = hidden_dim
         self.top_k = top_k
         self.firing_threshold = firing_threshold
+        self.tau = gumbel_tau
+        self.tau_min = tau_min
         self.path_names = list(paths.keys())
+        n_paths = len(paths)
 
         self.paths = nn.ModuleDict(paths)
 
-        self.gate = PathGate(hidden_dim, len(paths))
+        self.gate = PathGate(hidden_dim, n_paths)
 
         # Per-path output projection back to hidden_dim
         self.out_projs = nn.ModuleDict(
@@ -84,6 +108,28 @@ class FiringRouter(nn.Module):
 
         # Learned blend coefficient α: output = α*routed + (1-α)*passthrough
         self.blend = nn.Parameter(torch.tensor(0.0))   # sigmoid(0) = 0.5
+
+        # Markov decision tree with Bayesian Thompson Sampling
+        self.markov = MarkovDecisionTree(
+            n_paths=n_paths,
+            hidden_dim=hidden_dim,
+            lsh_dim=markov_lsh_dim,
+            capacity=markov_capacity,
+            history_len=markov_history,
+        )
+
+        # Last recorded state hash (for deferred observe_outcome calls)
+        self._last_hash: Optional[str] = None
+        self._last_fired_indices: List[int] = []
+
+    # -----------------------------------------------------------------------
+    # Temperature annealing (call from training loop)
+    # -----------------------------------------------------------------------
+
+    def anneal_temperature(self, factor: float = 0.995) -> float:
+        """Multiply tau by factor, clamp to tau_min. Returns new tau."""
+        self.tau = max(self.tau_min, self.tau * factor)
+        return self.tau
 
     # -----------------------------------------------------------------------
     # Forward
@@ -96,19 +142,34 @@ class FiringRouter(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor, List[str]]:
         """
         x       : (B, hidden_dim)
-        training: if True use soft weights; if False hard top-k
+        training: if True use Gumbel-Softmax; if False hard top-k
         Returns : (output, gate_weights, fired_names)
         """
         B, H = x.shape
         device = x.device
 
-        gate_weights = self.gate(x)                                     # (B, n_paths)
-        k = min(self.top_k, len(self.path_names))
-        top_k_vals, top_k_indices = gate_weights.topk(k, dim=-1)       # (B, k)
+        # Raw gate logits
+        logits = self.gate(x)                                       # (B, n_paths)
 
-        combined = torch.zeros(B, H, device=device)
-        total_weight = torch.zeros(B, device=device)
+        # Bayesian adjustment from Markov tree (additive in log-prob space)
+        # Use the mean hidden state as the state signature
+        state_sig = x.mean(0) if B > 1 else x.squeeze(0)
+        bayes_adj = self.markov.bayesian_logit_adjustment(state_sig)  # (n_paths,)
+        logits = logits + bayes_adj.unsqueeze(0)                    # broadcast (B, n_paths)
+
+        if training:
+            # Gumbel-Softmax: differentiable stochastic top-k
+            gate_weights = F.gumbel_softmax(logits, tau=self.tau, hard=False)
+        else:
+            gate_weights = torch.softmax(logits, dim=-1)
+
+        k = min(self.top_k, len(self.path_names))
+        top_k_vals, top_k_indices = gate_weights.topk(k, dim=-1)   # (B, k)
+
+        combined      = torch.zeros(B, H, device=device)
+        total_weight  = torch.zeros(B, device=device)
         fired_set: set = set()
+        fired_indices: List[int] = []
 
         for k_pos in range(k):
             path_indices = top_k_indices[:, k_pos]     # (B,)
@@ -116,19 +177,21 @@ class FiringRouter(nn.Module):
             above_thresh  = path_weights > self.firing_threshold
 
             for path_idx in path_indices[above_thresh].unique().tolist():
-                path_name = self.path_names[int(path_idx)]
+                path_idx = int(path_idx)
+                path_name = self.path_names[path_idx]
                 fired_set.add(path_name)
+                if path_idx not in fired_indices:
+                    fired_indices.append(path_idx)
 
-                # Which batch elements route through this path at this k_pos?
-                batch_mask = above_thresh & (path_indices == int(path_idx))
+                batch_mask = above_thresh & (path_indices == path_idx)
                 if not batch_mask.any():
                     continue
 
-                path_out = self.paths[path_name](x[batch_mask])        # (m, H)
-                proj_out = self.out_projs[path_name](path_out)         # (m, H)
-                w = gate_weights[batch_mask, int(path_idx)].unsqueeze(-1)
-                combined[batch_mask] += w * proj_out
-                total_weight[batch_mask] += gate_weights[batch_mask, int(path_idx)]
+                path_out = self.paths[path_name](x[batch_mask])         # (m, H)
+                proj_out = self.out_projs[path_name](path_out)          # (m, H)
+                w = gate_weights[batch_mask, path_idx].unsqueeze(-1)
+                combined[batch_mask]     += w * proj_out
+                total_weight[batch_mask] += gate_weights[batch_mask, path_idx]
 
         # Normalise fired outputs; passthrough where nothing fired
         fired_mask = total_weight > 0
@@ -139,10 +202,29 @@ class FiringRouter(nn.Module):
         combined[~fired_mask] = x[~fired_mask]
 
         # Residual blend
-        alpha = torch.sigmoid(self.blend)
+        alpha  = torch.sigmoid(self.blend)
         output = alpha * combined + (1.0 - alpha) * x
 
+        # Record decision in Markov tree for subsequent observe_outcome()
+        self._last_hash = self.markov.record(state_sig, fired_indices)
+        self._last_fired_indices = fired_indices
+
         return output, gate_weights, sorted(fired_set)
+
+    # -----------------------------------------------------------------------
+    # Live policy updating (no gradient required)
+    # -----------------------------------------------------------------------
+
+    def observe_outcome(self, reward: float) -> None:
+        """
+        Push the scalar reward back to the Markov tree for the most recent
+        routing decision.  Call this after evaluating the quality of the
+        step that used the output of the last forward() call.
+
+        reward > 0 : success  → increases alpha (favours those paths)
+        reward ≤ 0 : failure  → increases beta  (disfavours those paths)
+        """
+        self.markov.observe_outcome(reward)
 
     # -----------------------------------------------------------------------
     # Diversity / orthogonality loss
@@ -167,3 +249,21 @@ class FiringRouter(nn.Module):
         """Average gate probability per path (for logging)."""
         avg = gate_weights.mean(0)
         return {name: float(avg[i]) for i, name in enumerate(self.path_names)}
+
+    def markov_stats(self) -> Dict[str, Dict]:
+        """Pass-through to MarkovDecisionTree.path_stats()."""
+        return self.markov.path_stats()
+
+    def governor_summary(self, gate_weights: torch.Tensor) -> Dict:
+        """Combined routing + Markov stats for a single logging call."""
+        return {
+            "routing": self.routing_stats(gate_weights),
+            "markov":  self.markov_stats(),
+            "tau":     self.tau,
+            "blend":   float(torch.sigmoid(self.blend)),
+            "n_states": len(self.markov),
+        }
+
+
+# Backward-compat alias
+FiringRouter = StochasticFiringRouter

--- a/governor/hyperconnection.py
+++ b/governor/hyperconnection.py
@@ -1,0 +1,213 @@
+"""
+governor/hyperconnection.py
+============================
+HyperConnectionLayer — Multi-Head Cross-Attention residual hyperconnections.
+
+Each module output attends to all other module outputs, enriching its
+representation with cross-module information while preserving identity
+through a residual path.
+
+Orthogonality
+  A diversity loss identical in spirit to FiringRouter.diversity_loss()
+  is applied to the cross-attention weight matrices, encouraging each
+  module to attend to *different* aspects of the module pool — preventing
+  collapse where all modules attend to the same source.
+
+Architecture
+  For N modules with hidden_dim H:
+    Q_i = W_Q_i · x_i            (B, H)
+    K_j = W_K · x_j  ∀ j        (N, B, H) — shared key projection
+    V_j = W_V · x_j  ∀ j        (N, B, H) — shared value projection
+    a_i = softmax(Q_i · K^T / √H_head)   (B, N)
+    c_i = Σ_j a_i_j · V_j               (B, H)
+    y_i = x_i + gate_i · c_i            residual blend
+
+  gate_i is a learned scalar per module (sigmoid-initialised to ~0.1 so
+  the hyperconnection starts weak and grows as training proceeds).
+
+Usage
+-----
+    hc = HyperConnectionLayer(module_names=["nlp","vision","audio"], hidden_dim=896)
+
+    # In the forward pass after all module outputs are computed:
+    enriched = hc({"nlp": h_nlp, "vision": h_vision, "audio": h_audio})
+    # enriched["nlp"], enriched["vision"], ... each is (B, H)
+
+    # Orthogonality loss (add to total loss during training):
+    loss += hc.diversity_loss(enriched)
+"""
+
+from typing import Dict, List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class HyperConnectionLayer(nn.Module):
+    """
+    Multi-Head Cross-Attention residual hyperconnection layer.
+
+    Parameters
+    ----------
+    module_names : ordered list of module names that participate
+    hidden_dim   : shared hidden dimension H
+    num_heads    : number of attention heads (must divide hidden_dim)
+    gate_init    : initial logit for the residual blend gate
+                   (sigmoid(gate_init) ≈ 0.12 by default — weak start)
+    """
+
+    def __init__(
+        self,
+        module_names: List[str],
+        hidden_dim: int = 896,
+        num_heads: int = 8,
+        gate_init: float = -2.0,
+    ):
+        super().__init__()
+        assert hidden_dim % num_heads == 0, (
+            f"hidden_dim ({hidden_dim}) must be divisible by num_heads ({num_heads})"
+        )
+        self.module_names = list(module_names)
+        self.hidden_dim   = hidden_dim
+        self.num_heads    = num_heads
+        self.head_dim     = hidden_dim // num_heads
+        self.n            = len(module_names)
+        self._name_to_idx = {name: i for i, name in enumerate(module_names)}
+
+        # Per-module query projections (so each module attends differently)
+        self.W_Q = nn.ModuleDict(
+            {name: nn.Linear(hidden_dim, hidden_dim, bias=False) for name in module_names}
+        )
+
+        # Shared key / value projections (pool keys from all modules jointly)
+        self.W_K = nn.Linear(hidden_dim, hidden_dim, bias=False)
+        self.W_V = nn.Linear(hidden_dim, hidden_dim, bias=False)
+
+        # Per-module output projection (after attention aggregation)
+        self.W_O = nn.ModuleDict(
+            {name: nn.Linear(hidden_dim, hidden_dim, bias=False) for name in module_names}
+        )
+
+        # Per-module residual gate: y_i = x_i + sigmoid(gate_i) * c_i
+        self.gates = nn.ParameterDict(
+            {name: nn.Parameter(torch.tensor(gate_init)) for name in module_names}
+        )
+
+        # LayerNorm per module (post-residual)
+        self.norms = nn.ModuleDict(
+            {name: nn.LayerNorm(hidden_dim) for name in module_names}
+        )
+
+        self.scale = self.head_dim ** -0.5
+
+    # -----------------------------------------------------------------------
+    # Forward
+    # -----------------------------------------------------------------------
+
+    def forward(
+        self,
+        module_outputs: Dict[str, torch.Tensor],
+    ) -> Dict[str, torch.Tensor]:
+        """
+        module_outputs : dict name → (B, H) tensors
+                         (missing modules are skipped gracefully)
+        Returns        : dict name → (B, H) enriched tensors
+        """
+        # Only process names we know; skip unknowns
+        active = [n for n in self.module_names if n in module_outputs]
+        if not active:
+            return module_outputs
+
+        # Stack all active outputs: (N_active, B, H)
+        stacked = torch.stack([module_outputs[n] for n in active], dim=0)  # (N, B, H)
+        N, B, H = stacked.shape
+
+        # Shared K, V across all active modules: (N, B, H)
+        K_all = self.W_K(stacked)   # (N, B, H)
+        V_all = self.W_V(stacked)   # (N, B, H)
+
+        # Reshape for multi-head: (N, B, n_heads, head_dim)
+        def to_heads(t: torch.Tensor) -> torch.Tensor:
+            # t: (N, B, H) → (N, B, n_heads, head_dim)
+            return t.view(N, B, self.num_heads, self.head_dim)
+
+        K_h = to_heads(K_all)   # (N, B, n_heads, head_dim)
+        V_h = to_heads(V_all)   # (N, B, n_heads, head_dim)
+
+        enriched: Dict[str, torch.Tensor] = {}
+
+        for name in active:
+            x_i = module_outputs[name]  # (B, H)
+
+            # Per-module query
+            q = self.W_Q[name](x_i)    # (B, H)
+            q = q.view(B, self.num_heads, self.head_dim)  # (B, n_heads, head_dim)
+
+            # Attention scores: q × K^T
+            # q: (B, n_heads, head_dim) × K_h: (N, B, n_heads, head_dim)
+            # → (B, n_heads, N)
+            scores = torch.einsum("bnh,nbnh->bnn2", q, K_h)
+            # Simpler explicit einsum: (B, n_heads, N)
+            scores = torch.einsum("bnh,ibnh->bin", q, K_h) * self.scale   # (B, n_heads, N)
+            # Rearrange: (B, n_heads, N)
+            attn = torch.softmax(scores, dim=-1)   # (B, n_heads, N)
+
+            # Weighted sum of values: (B, n_heads, head_dim)
+            # V_h: (N, B, n_heads, head_dim) → need (B, n_heads, N, head_dim)
+            V_perm = V_h.permute(1, 2, 0, 3)       # (B, n_heads, N, head_dim)
+            c = (attn.unsqueeze(-1) * V_perm).sum(dim=2)  # (B, n_heads, head_dim)
+            c = c.reshape(B, H)                     # (B, H)
+
+            # Output projection + residual gate
+            c_proj  = self.W_O[name](c)             # (B, H)
+            gate    = torch.sigmoid(self.gates[name])
+            y       = x_i + gate * c_proj           # (B, H)
+            enriched[name] = self.norms[name](y)    # (B, H)
+
+        # Pass through any names not in our module list unchanged
+        for name, val in module_outputs.items():
+            if name not in enriched:
+                enriched[name] = val
+
+        return enriched
+
+    # -----------------------------------------------------------------------
+    # Diversity / orthogonality loss
+    # -----------------------------------------------------------------------
+
+    def diversity_loss(
+        self,
+        module_outputs: Dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        """
+        Penalise correlated cross-module representations.
+
+        Stacks all active module outputs, column-normalises, computes the
+        Gram matrix, and returns ||G − I||_F.  Encourages each module's
+        output to be orthogonal to every other module's output.
+        """
+        active = [n for n in self.module_names if n in module_outputs]
+        if len(active) < 2:
+            device = next(iter(module_outputs.values())).device
+            return torch.tensor(0.0, device=device)
+
+        # Each x: (B, H) → mean over batch → (H,)
+        vecs = torch.stack(
+            [module_outputs[n].mean(0) for n in active], dim=0
+        )  # (N, H)
+        vecs = F.normalize(vecs, dim=-1)    # (N, H)
+        gram = vecs @ vecs.t()              # (N, N)
+        I    = torch.eye(gram.size(0), device=gram.device)
+        return (gram - I).pow(2).mean()
+
+    # -----------------------------------------------------------------------
+    # Convenience
+    # -----------------------------------------------------------------------
+
+    def gate_stats(self) -> Dict[str, float]:
+        """Current blend gate magnitudes per module (for logging)."""
+        return {
+            name: float(torch.sigmoid(self.gates[name]))
+            for name in self.module_names
+        }

--- a/governor/markov_tree.py
+++ b/governor/markov_tree.py
@@ -1,0 +1,235 @@
+"""
+governor/markov_tree.py
+========================
+MarkovDecisionTree — past decision / outcome registry with Bayesian updating.
+
+Structure
+---------
+Each node in the tree represents a (state, routing_decision) pair.
+The tree branches on routing decisions made from similar states.
+
+State identity
+  Hidden states are too high-dimensional to use directly as keys.
+  We hash them with sign-LSH: take sign(x @ random_projections) → a
+  fixed-length binary string.  Similar states cluster to the same hash
+  with high probability (locality-sensitive hashing).
+
+Bayesian updating
+  For each (state_hash, path_index) pair we maintain a Beta(α, β)
+  distribution over success probability.
+  - Prior: α=1, β=1 (uniform — no assumption)
+  - On success (reward > 0): α += reward_magnitude
+  - On failure (reward ≤ 0): β += |reward_magnitude|
+  Thompson Sampling: draw p ~ Beta(α, β) for each path; use log(p) as
+  an additive logit adjustment biasing future routing.
+
+Live policy adjusting
+  call observe_outcome(reward) after each step to update the tree.
+  No gradient required — purely count-based Bayesian update.
+"""
+
+import hashlib
+import math
+from collections import deque
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+
+class _Node:
+    """Single tree node: Beta params for one (state_hash, path_idx) pair."""
+    __slots__ = ("alpha", "beta", "visit_count")
+
+    def __init__(self):
+        self.alpha = 1.0        # Beta prior: successes + 1
+        self.beta  = 1.0        # Beta prior: failures  + 1
+        self.visit_count = 0
+
+    def update(self, reward: float):
+        clipped = max(-10.0, min(10.0, reward))
+        if clipped > 0:
+            self.alpha += clipped
+        else:
+            self.beta  += abs(clipped)
+        self.visit_count += 1
+
+    def thompson_sample(self) -> float:
+        """Draw one sample from Beta(α, β) — approximated via ratio of Gammas."""
+        # Use the mean as a deterministic approximation when counts are low
+        # and sampling otherwise (no scipy dependency)
+        if self.visit_count < 3:
+            return self.alpha / (self.alpha + self.beta)
+        # Approximate Beta sample: u^(1/α) / (u^(1/α) + v^(1/β))
+        import random
+        u = random.random() ** (1.0 / self.alpha)
+        v = random.random() ** (1.0 / self.beta)
+        denom = u + v
+        return u / denom if denom > 0 else 0.5
+
+    @property
+    def mean(self) -> float:
+        return self.alpha / (self.alpha + self.beta)
+
+
+class MarkovDecisionTree(nn.Module):
+    """
+    Hash-backed Markov decision registry with Thompson-Sampling Bayesian priors.
+
+    Parameters
+    ----------
+    n_paths      : number of routing paths (must match FiringRouter)
+    lsh_dim      : number of random projections for state hashing
+    capacity     : maximum number of distinct state hashes to retain
+    history_len  : rolling window of recent decisions for live updates
+    """
+
+    def __init__(
+        self,
+        n_paths:     int = 6,
+        hidden_dim:  int = 896,
+        lsh_dim:     int = 64,
+        capacity:    int = 8192,
+        history_len: int = 128,
+    ):
+        super().__init__()
+        self.n_paths    = n_paths
+        self.lsh_dim    = lsh_dim
+        self.capacity   = capacity
+
+        # Random projection matrix for LSH hashing (not trained)
+        self.register_buffer(
+            "lsh_proj",
+            torch.randn(hidden_dim, lsh_dim) / math.sqrt(lsh_dim),
+        )
+
+        # Registry: state_hash_str → list of _Node, one per path
+        self._registry: Dict[str, List[_Node]] = {}
+
+        # Ring buffer: recent (hash, fired_path_indices) for live updating
+        self._history: deque = deque(maxlen=history_len)
+
+        # Aggregate path priors across all states (smoothed)
+        # Shape (n_paths,) — updated with each observe_outcome call
+        self.register_buffer("path_priors", torch.ones(n_paths) * 0.5)
+
+    # -----------------------------------------------------------------------
+    # State hashing
+    # -----------------------------------------------------------------------
+
+    def _hash(self, state: torch.Tensor) -> str:
+        """
+        LSH hash of a hidden state vector.
+        state: (H,) or (B, H) — if batched, hash the mean.
+        Returns a hex string.
+        """
+        with torch.no_grad():
+            if state.dim() > 1:
+                state = state.float().mean(0)
+            proj = (state.float() @ self.lsh_proj.float())   # (lsh_dim,)
+            bits = (proj > 0).cpu().numpy().tobytes()
+        return hashlib.md5(bits).hexdigest()[:16]
+
+    def _get_nodes(self, state_hash: str) -> List[_Node]:
+        """Retrieve or create nodes for a state hash."""
+        if state_hash not in self._registry:
+            if len(self._registry) >= self.capacity:
+                # Evict the least-visited state
+                victim = min(
+                    self._registry,
+                    key=lambda k: sum(n.visit_count for n in self._registry[k]),
+                )
+                del self._registry[victim]
+            self._registry[state_hash] = [_Node() for _ in range(self.n_paths)]
+        return self._registry[state_hash]
+
+    # -----------------------------------------------------------------------
+    # Record / update
+    # -----------------------------------------------------------------------
+
+    def record(self, state: torch.Tensor, fired_indices: List[int]) -> str:
+        """Record a routing decision before the outcome is known."""
+        h = self._hash(state)
+        self._get_nodes(h)                          # ensure nodes exist
+        self._history.append((h, fired_indices))
+        return h
+
+    def observe_outcome(self, reward: float) -> None:
+        """
+        Live policy update: push the outcome reward back onto the most recent
+        decision recorded via record().
+        """
+        if not self._history:
+            return
+        state_hash, fired_indices = self._history[-1]
+        nodes = self._get_nodes(state_hash)
+        for idx in fired_indices:
+            if 0 <= idx < self.n_paths:
+                nodes[idx].update(reward)
+        # Refresh aggregate priors
+        self._refresh_priors()
+
+    def _refresh_priors(self):
+        """Recompute aggregate path_priors from all nodes (mean of Beta means)."""
+        if not self._registry:
+            return
+        totals = [0.0] * self.n_paths
+        counts = [0]   * self.n_paths
+        for nodes in self._registry.values():
+            for i, node in enumerate(nodes):
+                totals[i] += node.mean
+                counts[i] += 1
+        with torch.no_grad():
+            for i in range(self.n_paths):
+                if counts[i] > 0:
+                    self.path_priors[i] = totals[i] / counts[i]
+
+    # -----------------------------------------------------------------------
+    # Bayesian logit adjustment (Thompson Sampling)
+    # -----------------------------------------------------------------------
+
+    def bayesian_logit_adjustment(self, state: torch.Tensor) -> torch.Tensor:
+        """
+        Returns (n_paths,) additive logit adjustments based on Thompson
+        Sampling from the Beta distribution of each path at the current state.
+
+        Values are log-probability scale so they can be directly added to
+        gate logits before softmax.
+        """
+        h = self._hash(state)
+        nodes = self._get_nodes(h)
+
+        samples = torch.tensor(
+            [node.thompson_sample() for node in nodes],
+            dtype=torch.float32,
+            device=self.path_priors.device,
+        )
+        # log-prob: log(p) so high-success paths get positive adjustment
+        adj = torch.log(samples.clamp(min=1e-6))
+        # Normalise to zero-mean so we don't shift the total activation level
+        adj = adj - adj.mean()
+        return adj
+
+    # -----------------------------------------------------------------------
+    # Statistics
+    # -----------------------------------------------------------------------
+
+    def path_stats(self) -> Dict[str, Dict]:
+        """Return per-path aggregate statistics across all states."""
+        stats: Dict[str, Dict] = {}
+        for path_idx in range(self.n_paths):
+            nodes = [
+                self._registry[h][path_idx]
+                for h in self._registry
+                if path_idx < len(self._registry[h])
+            ]
+            if not nodes:
+                stats[f"path_{path_idx}"] = {"mean": 0.5, "visits": 0}
+                continue
+            mean     = sum(n.mean          for n in nodes) / len(nodes)
+            visits   = sum(n.visit_count   for n in nodes)
+            stats[f"path_{path_idx}"] = {"mean": mean, "visits": visits}
+        return stats
+
+    def __len__(self) -> int:
+        return len(self._registry)


### PR DESCRIPTION
…ections

- governor/markov_tree.py: LSH state hashing + Beta(α,β) per (state,path) pair; Thompson Sampling logit adjustment; capacity-limited LRU registry
- governor/firing_router.py: upgrade FiringRouter → StochasticFiringRouter with Gumbel-softmax training, Markov/Bayesian logit bias, observe_outcome() for live policy updating; FiringRouter alias kept for back-compat
- governor/hyperconnection.py: HyperConnectionLayer — per-module Q + shared K/V multi-head cross-attention; residual blend gates; diversity_loss() for orthogonal module representations
- ONI.py: import HyperConnectionLayer; add self.hyper_connections in __init__; enrich nlp/vision/audio outputs via MHC before multi-modal attention; invoke governor on meta_output in forward(); add observe_outcome(reward) method; fix duplicate return in step()

https://claude.ai/code/session_01WEEWKPAv69qaUpnhPtdce6