### PR TITLE
Refactor imports: remove fallbacks, add latent residual block

### DIFF
--- a/ONI.py
+++ b/ONI.py
@@ -6,236 +6,76 @@ from collections import deque
 import random
 import threading
 import time
-import re  # Needed for regex in animate method
-import pytesseract  # For OCR
-import cv2  # For computer vision
-from PIL import ImageGrab  # For screen capture
-import pyautogui  # For mouse and keyboard automation
-import pyaudio  # For audio processing
-from selenium import webdriver  # For browser automation
-from selenium.webdriver.common.by import By  # For locating elements
-import matplotlib.pyplot as plt  # For plotting images
-import PyPDF2  # Ensure that PDF reading works
-import torch.autograd as autograd  # If used elsewhere in the code
+import re
+import pytesseract
+import cv2
+from PIL import ImageGrab
+import pyautogui
+import pyaudio
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+import matplotlib.pyplot as plt
+import PyPDF2
+import torch.autograd as autograd
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from transformers.image_utils import load_image
 import os
 import logging
 
-# Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Device configuration
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-# Import modules with error handling
-try:
-    from tools import file_preprocessor
-except ImportError:
-    logger.warning("file_preprocessor not found, using fallback")
-    class file_preprocessor:
-        @staticmethod
-        def process_file(path):
-            return ""
+# ── core modules (paths confirmed) ────────────────────────────────────────────
+from tools import file_preprocessor
+from modules.vision import oni_vision as vision
+from modules.audio import oni_audio as audio
+from modules.attention.multi_modal_attention import MultiModalAttention
+from modules.memory.oni_memoryv2 import QuantumEnhancedMemory as memory
+from tools import oni_netmonitor as netmon
+from tools import oni_portscanner as ps
+from modules.ExecutiveFunction.executive_system import ExecutiveFunctionSystem as exec_func
+from modules.oni_metacognition import MetaCognitionModule
+from modules.oni_homeostasis import HomeostaticController
+from modules.NLP.oni_NLP import OptimizedNLPModule as nlp_module
+from modules.emotion.oni_emotions import EmotionalEnergyModel
+from modules.emotion.oni_compassion import ONICompassionSystem, Agent, CompassionEngine
+from modules.NLP.oni_chain_of_thought import ChainOfThought
+from modules.feedforward.hyper_ffn import HypersphericalFFN
+from tools.calculator import Calculator
+from tools.drawer import pipe
+from tools.animator import pipeline
+from tools.oni_crypto_trade import TradingBot
+from modules.NLP.oni_Tokenizer import MultitokenBPETokenizer
+from tools.ai_tools_registry import AIToolsRegistry
+from tools.ai_tools_interface import AIToolsInterface
+from modules.skills.dynamic_module_injector import DynamicModuleInjector
+from modules.dynamics.oni_dyn import DynamicSynapse
+from modules.dynamics.oni_dynLayer import DynamicLayer
+from modules.dynamics.energy_based_synapse import EnergyBasedSynapse
+from modules.agents.micro_agent import MicroAgent
+from modules.planner.gru_planner import GRUPlanner
+from modules.memory.memory_ensemble import MemoryEnsemble
+from governor.firing_router import FiringRouter
+from governor.hyperconnection import HyperConnectionLayer
+from modules.attention.temporal_tri_attention import TemporalSparseTrifocusedAttention
+from modules.attention.latent_residual_block import LatentResidualBlock
 
-try:
-    from modules.vision import oni_vision as vision
-except ImportError:
-    logger.warning("oni_vision not found, using fallback")
-    class vision:
-        @staticmethod
-        def process_input(*args, **kwargs):
-            return torch.zeros(1, 896), 0.0
-
-try:
-    from modules.audio import oni_audio as audio
-except ImportError:
-    logger.warning("oni_audio not found, using fallback")
-    class audio:
-        @staticmethod
-        def forward(*args, **kwargs):
-            return torch.zeros(1, 896), 0.0
-
-try:
-    from modules.attention import multi_modal_attention as MultiModalAttention
-except ImportError:
-    logger.warning("oni_MM_attention not found, using fallback")
-    class MultiModalAttention:
-        def __init__(self, dim):
-            self.dim = dim
-        def forward(self, x1, x2, x3):
-            return x1
-
-try:
-    from modules.memory.oni_memoryv2 import QuantumEnhancedMemory as memory 
-except ImportError:
-    logger.warning("oni_memory not found, using fallback")
-    class memory:
-        @staticmethod
-        def update_memory(*args, **kwargs):
-            pass
-
-try:
-    from modules.skills import oni_netmonitor as netmon
-except ImportError:
-    logger.warning("oni_netmonitor not found, using fallback")
-    class netmon:
-        @staticmethod
-        def start():
-            pass
-
-try:
-    from modules.skills import oni_portscanner as ps
-except ImportError:
-    logger.warning("oni_portscanner not found, using fallback")
-    class ps:
-        @staticmethod
-        def start_scan():
-            pass
-
-try:
-    from modules import oni_executive_function as exec_func
-except ImportError:
-    logger.warning("oni_executive_function not found, using fallback")
-    class exec_func:
-        @staticmethod
-        def execute(*args, **kwargs):
-            pass
-
-try:
-    from modules.oni_metacognition import MetaCognitionModule
-except ImportError:
-    logger.warning("oni_metacognition not found, using fallback")
-    class MetaCognitionModule:
-        def __init__(self, dim):
-            self.hidden_dim = dim
-        def forward(self, x, conflict_threshold=0.5):
-            return x, 0.5, []
-
-try:
-    from modules.oni_homeostasis import HomeostaticController
-except ImportError:
-    logger.warning("oni_homeostasis not found, using fallback")
-    class HomeostaticController:
-        def __init__(self, input_dim, hidden_dim):
-            pass
-        def forward(self, x, state):
-            return x, 0.0
-
-try:
-    from modules.NLP.oni_NLP import OptimizedNLPModule as nlp_module
-except ImportError:
-    logger.warning("oni_NLP not found, using fallback")
-    class nlp_module:
-        def __init__(self, config):
-            self.embedding = nn.Embedding(1000, 896)
-        def forward(self, x, y=None):
-            return x, 0.0
-        def identify_tasks(self, text):
-            return []
-        def generate(self, text):
-            return "Generated response"
-
-# Import advanced modules
-try:
-    from modules.oni_emotions import EmotionalEnergyModel
-except ImportError:
-    logger.warning("oni_emotions not found, using fallback")
-    class EmotionalEnergyModel:
-        def __init__(self, hidden_dim, init_energy=100):
-            self.hidden_dim = hidden_dim
-        def forward(self, x):
-            return x
-        def get_emotional_state(self):
-            return {'current_emotion': 'neutral', 'intensity': 0.5, 'valence': 0.0, 'arousal': 0.0, 'energy': 100.0}
-
-try:
-    from modules.oni_compassion import ONICompassionSystem, Agent, CompassionEngine
-except ImportError:
-    logger.warning("oni_compassion not found, using fallback")
-    class ONICompassionSystem:
-        def __init__(self, reality_state=None):
-            self.reality_state = reality_state or {}
-        def plan_compassionate_action(self, target_agent_id):
-            return None
-        def execute_multi_agent_planning(self):
-            return {'status': 'no_compassion_system'}
-        def get_system_status(self):
-            return {'error': 'Compassion system not available'}
-
-try:
-    from modules.oni_chain_of_thought import ChainOfThought
-except ImportError:
-    logger.warning("oni_chain_of_thought not found, using fallback")
-    class ChainOfThought:
-        def __init__(self, input_dim, memory_size):
-            self.input_dim = input_dim
-            self.memory_size = memory_size
-        def forward(self, x):
-            return x
-
+# ── FatDiffuser: not yet extracted from latent_space_operations; stub until then
 try:
     from modules.latent_space_operations import FatDiffuser
 except ImportError:
-    logger.warning("oni_imagination_diffusion not found, using fallback")
     class FatDiffuser:
         def __init__(self, vocab_size, hidden_dim, num_heads=16, timesteps=30, max_seq_len=512):
             pass
         def forward(self, input_ids):
             return torch.zeros(1, 10, 300000)
 
-try:
-    from modules.oni_dynLayer import DynamicLayer
-except ImportError:
-    logger.warning("oni_dynLayer not found, using fallback")
-    class DynamicLayer:
-        def __init__(self, d_model, d_ff, radius=1.0, num_heads=8, noise_factor=0.1):
-            pass
-        def forward(self, x, mask=None, time_step=None):
-            return x, torch.tensor(0.0)
-
-try:
-    from modules.oni_hyper import HypersphericalFFN
-except ImportError:
-    logger.warning("oni_hyper not found, using fallback")
-    class HypersphericalFFN:
-        def __init__(self, d_model, d_ff, radius, timesteps):
-            pass
-        def forward(self, x, t):
-            return x
-
-# Import tools with error handling
-try:
-    from tools.calculator import Calculator
-    calculator = Calculator()
-except ImportError:
-    logger.warning("Calculator not found, using fallback")
-    class Calculator:
-        def calculate(self, expr):
-            return "Calculation not available"
-    calculator = Calculator()
-
-try:
-    from tools.drawer import pipe
-except ImportError:
-    logger.warning("Drawer not found, using fallback")
-    def pipe(*args, **kwargs):
-        return type('obj', (object,), {'images': [None]})()
-
-try:
-    from tools.animator import pipeline
-except ImportError:
-    logger.warning("Animator not found, using fallback")
-    def pipeline(*args, **kwargs):
-        return type('obj', (object,), {'frames': [[]]})()
-
-# Import external models with error handling
+# ── external LLM / vision models (large optional downloads) ───────────────────
 try:
     from transformers import AutoTokenizer, AutoModelForCausalLM, AutoProcessor, AutoModelForImageTextToText
-    
-    # Try to load Qwen model
     try:
         tokenizerQ = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-Coder-7B-Instruct")
         qwen = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2.5-Coder-7B-Instruct", torch_dtype=torch.bfloat16, device_map="auto")
@@ -243,8 +83,6 @@ try:
         logger.warning(f"Failed to load Qwen model: {e}")
         tokenizerQ = None
         qwen = None
-    
-    # Try to load vision model
     try:
         processor = AutoProcessor.from_pretrained("microsoft/Phi-3.5-vision-instruct")
         model = AutoModelForImageTextToText.from_pretrained("microsoft/Phi-3.5-vision-instruct", torch_dtype=torch.bfloat16, device_map="auto")
@@ -252,58 +90,17 @@ try:
         logger.warning(f"Failed to load vision model: {e}")
         processor = None
         model = None
-        
 except ImportError:
-    logger.warning("Transformers not available, using fallbacks")
+    logger.warning("Transformers not available")
     tokenizerQ = None
     qwen = None
     processor = None
     model = None
 
-# Import trading module with error handling
-try:
-    from modules.skills.oni_crypto_trade import TradingBot
-    trader = TradingBot
-except ImportError:
-    logger.warning("Trading module not found, using fallback")
-    class TradingBot:
-        def __init__(self, *args, **kwargs):
-            pass
-    trader = TradingBot
-
-# Import tokenizer with error handling
-try:
-    from modules.NLP.Tokenizer import MultitokenBPETokenizer
-    tokenizer = MultitokenBPETokenizer()
-except ImportError:
-    logger.warning("Tokenizer not found, using fallback")
-    class MultitokenBPETokenizer:
-        def encode(self, text):
-            return [1, 2, 3]
-        def decode(self, ids):
-            return "decoded text"
-    tokenizer = MultitokenBPETokenizer()
-from tools.ai_tools_registry import AIToolsRegistry
-from tools.ai_tools_interface import AIToolsInterface
-# Fallback implementations for missing components
-from modules.skills.dynamic_module_injector import DynamicModuleInjector
-
-from modules.dynamics.oni_dyn import DynamicSynapse
-from modules.dynamics.oni_dynLayer import DynamicLayer
-
-from modules.dynamics.energy_based_synapse import EnergyBasedSynapse
-
-from modules.agents.micro_agent import MicroAgent
-from modules.planner.gru_planner import GRUPlanner
-from modules.memory.memory_ensemble import MemoryEnsemble
-from governor.firing_router import FiringRouter
-from governor.hyperconnection import HyperConnectionLayer
-
-try:
-    from modules.attention.temporal_tri_attention import TemporalSparseTrifocusedAttention
-except ImportError:
-    logger.warning("TrifocusedAttention not found, using EfficientAttention fallback")
-    from modules.attention.efficient_attention import EfficientAttention
+# ── module-level singletons ────────────────────────────────────────────────────
+calculator = Calculator()
+tokenizer  = MultitokenBPETokenizer()
+trader     = TradingBot
 
 
 class RBM:
@@ -344,7 +141,6 @@ class RecurrentQNetwork(nn.Module):
         lstm_out, hidden = self.lstm(state, hidden)  # lstm_out: (batch_size, seq_len, hidden_dim)
         q_values = self.fc(lstm_out[:, -1, :])  # Take the output of the last time step
         return q_values, hidden
-import json
 
 
 class _RemovedMemoryManager:

--- a/modules/attention/latent_residual_block.py
+++ b/modules/attention/latent_residual_block.py
@@ -1,0 +1,306 @@
+"""
+modules/attention/latent_residual_block.py
+==========================================
+Transformer-style block combining:
+  - LatentAttention       : Perceiver-style bottleneck (global context)
+  - ResidualAttention     : Local self-attention with KV-cache support
+  - MemoryAugmentedAttention : External / persistent memory read
+  - Orthogonal layer scales  : independent gamma per path
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+from typing import Any, Dict, Optional, Tuple
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Primitives
+# ──────────────────────────────────────────────────────────────────────────────
+
+class _RMSNorm(nn.Module):
+    def __init__(self, d_model: int, eps: float = 1e-8):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x: Tensor) -> Tensor:
+        norm = x.norm(2, dim=-1, keepdim=True) * (x.shape[-1] ** -0.5)
+        return self.weight * x / (norm + self.eps)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LatentAttention  (Perceiver-style two-stage bottleneck)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class LatentAttention(nn.Module):
+    """
+    Two-stage cross-attention through a learned latent bottleneck.
+
+    Stage 1 – compress : latents cross-attend to x  →  enriched latents (B, L, D)
+    Stage 2 – expand   : x cross-attends to latents →  context-enriched x (B, T, D)
+    """
+
+    def __init__(self, d_model: int, n_latents: int = 32,
+                 n_heads: int = 8, dropout: float = 0.1):
+        super().__init__()
+        assert d_model % n_heads == 0
+        self.n_heads   = n_heads
+        self.head_dim  = d_model // n_heads
+        self.scale     = self.head_dim ** -0.5
+
+        self.latents   = nn.Parameter(torch.randn(n_latents, d_model) * 0.02)
+        self.norm_x    = _RMSNorm(d_model)
+        self.norm_l    = _RMSNorm(d_model)
+
+        # compress projections
+        self.cq = nn.Linear(d_model, d_model, bias=False)
+        self.ck = nn.Linear(d_model, d_model, bias=False)
+        self.cv = nn.Linear(d_model, d_model, bias=False)
+
+        # expand projections
+        self.eq       = nn.Linear(d_model, d_model, bias=False)
+        self.ek       = nn.Linear(d_model, d_model, bias=False)
+        self.ev       = nn.Linear(d_model, d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        self.drop     = nn.Dropout(dropout)
+
+    def _attend(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+        B, Sq, _ = q.shape
+        Sk = k.shape[1]
+
+        def split(t, S):
+            return t.view(B, S, self.n_heads, self.head_dim).transpose(1, 2)
+
+        q, k, v = split(q, Sq), split(k, Sk), split(v, Sk)
+        w = self.drop(torch.softmax(torch.matmul(q, k.transpose(-2, -1)) * self.scale, dim=-1))
+        out = torch.matmul(w, v)
+        return out.transpose(1, 2).reshape(B, Sq, self.n_heads * self.head_dim)
+
+    def forward(self, x: Tensor,
+                return_latents: bool = False) -> Tuple[Tensor, Optional[Tensor]]:
+        B = x.shape[0]
+        x_n = self.norm_x(x)
+        latents = self.latents.unsqueeze(0).expand(B, -1, -1)
+        l_n = self.norm_l(latents)
+
+        # Stage 1: latents attend to x (compress)
+        enriched = self._attend(self.cq(l_n), self.ck(x_n), self.cv(x_n))  # (B, L, D)
+
+        # Stage 2: x attends to enriched latents (expand)
+        out = self.out_proj(
+            self._attend(self.eq(x_n), self.ek(enriched), self.ev(enriched))
+        )  # (B, T, D)
+
+        return (out, enriched) if return_latents else (out, None)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# ResidualAttention  (standard causal self-attention + KV-cache)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class ResidualAttention(nn.Module):
+    """Causal self-attention with optional KV-cache for autoregressive inference."""
+
+    def __init__(self, d_model: int, n_heads: int = 8, dropout: float = 0.1):
+        super().__init__()
+        assert d_model % n_heads == 0
+        self.n_heads  = n_heads
+        self.head_dim = d_model // n_heads
+        self.scale    = self.head_dim ** -0.5
+
+        self.norm = _RMSNorm(d_model)
+        self.q    = nn.Linear(d_model, d_model, bias=False)
+        self.k    = nn.Linear(d_model, d_model, bias=False)
+        self.v    = nn.Linear(d_model, d_model, bias=False)
+        self.out  = nn.Linear(d_model, d_model, bias=False)
+        self.drop = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        x: Tensor,
+        attn_mask: Optional[Tensor] = None,
+        past_kv: Optional[Tuple[Tensor, Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[Tensor, Optional[Tuple[Tensor, Tensor]]]:
+        B, T, D = x.shape
+        x_n = self.norm(x)
+
+        def split(t):
+            S = t.shape[1]
+            return t.view(B, S, self.n_heads, self.head_dim).transpose(1, 2)
+
+        q, k, v = split(self.q(x_n)), split(self.k(x_n)), split(self.v(x_n))
+
+        if past_kv is not None:
+            k = torch.cat([past_kv[0], k], dim=2)
+            v = torch.cat([past_kv[1], v], dim=2)
+
+        present_kv = (k, v) if use_cache else None
+
+        w = torch.matmul(q, k.transpose(-2, -1)) * self.scale
+        if attn_mask is not None:
+            w = w + attn_mask
+        w = self.drop(torch.softmax(w, dim=-1))
+        out = torch.matmul(w, v).transpose(1, 2).reshape(B, T, D)
+        return self.out(out), present_kv
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# MemoryAugmentedAttention
+# ──────────────────────────────────────────────────────────────────────────────
+
+class MemoryAugmentedAttention(nn.Module):
+    """x attends to a persistent learnable memory bank (or supplied external memory)."""
+
+    def __init__(self, d_model: int, n_heads: int = 8,
+                 n_memory_slots: int = 64, dropout: float = 0.1):
+        super().__init__()
+        assert d_model % n_heads == 0
+        self.n_heads  = n_heads
+        self.head_dim = d_model // n_heads
+        self.scale    = self.head_dim ** -0.5
+
+        self.memory = nn.Parameter(torch.randn(n_memory_slots, d_model) * 0.02)
+        self.norm   = _RMSNorm(d_model)
+        self.q      = nn.Linear(d_model, d_model, bias=False)
+        self.k      = nn.Linear(d_model, d_model, bias=False)
+        self.v      = nn.Linear(d_model, d_model, bias=False)
+        self.out    = nn.Linear(d_model, d_model, bias=False)
+        self.drop   = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        x: Tensor,
+        external_memory: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Tensor]:
+        B, T, D = x.shape
+        x_n = self.norm(x)
+        mem = external_memory if external_memory is not None \
+              else self.memory.unsqueeze(0).expand(B, -1, -1)
+
+        M = mem.shape[1]
+
+        def split_q(t):
+            return t.view(B, T, self.n_heads, self.head_dim).transpose(1, 2)
+
+        def split_m(t):
+            return t.view(B, M, self.n_heads, self.head_dim).transpose(1, 2)
+
+        q = split_q(self.q(x_n))
+        k = split_m(self.k(mem))
+        v = split_m(self.v(mem))
+
+        w = self.drop(torch.softmax(
+            torch.matmul(q, k.transpose(-2, -1)) * self.scale, dim=-1
+        ))
+        out = torch.matmul(w, v).transpose(1, 2).reshape(B, T, D)
+        return self.out(out), mem   # return mem unchanged; caller may update it
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# LatentResidualBlock
+# ──────────────────────────────────────────────────────────────────────────────
+
+class LatentResidualBlock(nn.Module):
+    """
+    Transformer-style block with latent + residual attention
+    and orthogonal hyperconnection layer scales.
+
+    Paths (each scaled by its own learnable gamma):
+      1. LatentAttention       – global context via Perceiver bottleneck
+      2. ResidualAttention     – local precision self-attention (always runs)
+      3. MemoryAugmentedAttention – optional persistent memory read
+      4. FFN                   – position-wise feed-forward
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        n_heads: int = 8,
+        n_latents: int = 32,
+        d_ff: int = None,
+        dropout: float = 0.1,
+        use_memory: bool = False,
+        n_memory_slots: int = 64,
+    ):
+        super().__init__()
+        self.d_model = d_model
+        d_ff = d_ff or d_model * 4
+
+        self.latent_attn   = LatentAttention(d_model, n_latents=n_latents,
+                                             n_heads=n_heads, dropout=dropout)
+        self.residual_attn = ResidualAttention(d_model, n_heads=n_heads,
+                                               dropout=dropout)
+
+        self.use_memory = use_memory
+        if use_memory:
+            self.memory_attn = MemoryAugmentedAttention(
+                d_model, n_heads=n_heads,
+                n_memory_slots=n_memory_slots, dropout=dropout,
+            )
+
+        self.ffn = nn.Sequential(
+            _RMSNorm(d_model),
+            nn.Linear(d_model, d_ff),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(d_ff, d_model),
+            nn.Dropout(dropout),
+        )
+
+        # Orthogonal layer scales (independent per path)
+        self.gamma_latent   = nn.Parameter(torch.ones(d_model) * 0.1)
+        self.gamma_residual = nn.Parameter(torch.ones(d_model) * 0.1)
+        self.gamma_memory   = nn.Parameter(torch.ones(d_model) * 0.1) if use_memory else None
+        self.gamma_ffn      = nn.Parameter(torch.ones(d_model) * 0.1)
+
+    def forward(
+        self,
+        x: Tensor,
+        attn_mask: Optional[Tensor] = None,
+        memory: Optional[Tensor] = None,
+        past_kv: Optional[Tuple[Tensor, Tensor]] = None,
+        use_cache: bool = False,
+    ) -> Tuple[Tensor, Dict[str, Any]]:
+        """
+        Args:
+            x:         (B, T, D) input tensor
+            attn_mask: optional additive attention mask for residual_attn
+            memory:    optional external memory tensor for memory_attn
+            past_kv:   optional KV-cache tuple (k, v) from a previous step
+            use_cache: if True, returns present KV-cache in state dict
+
+        Returns:
+            output: (B, T, D)
+            state:  dict with optional keys
+                    'present_kv', 'memory', 'latents', 'attn_out'
+        """
+        state: Dict[str, Any] = {}
+
+        # ── 1. Global context via latent bottleneck ───────────────────────────
+        latent_out, latents = self.latent_attn(x, return_latents=True)
+        state['attn_out'] = latent_out
+        x = x + self.gamma_latent * latent_out
+        if latents is not None:
+            state['latents'] = latents
+
+        # ── 2. Local precision: residual self-attention ───────────────────────
+        residual_out, present_kv = self.residual_attn(
+            x, attn_mask=attn_mask, past_kv=past_kv, use_cache=use_cache
+        )
+        x = x + self.gamma_residual * (residual_out - x)
+        if present_kv is not None:
+            state['present_kv'] = present_kv
+
+        # ── 3. Memory augmentation (optional) ────────────────────────────────
+        if self.use_memory:
+            mem_out, new_memory = self.memory_attn(x, external_memory=memory)
+            x = x + self.gamma_memory * (mem_out - x)
+            state['memory'] = new_memory
+
+        # ── 4. FFN ────────────────────────────────────────────────────────────
+        x = x + self.gamma_ffn * self.ffn(x)
+
+        return x, state

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -33,6 +33,11 @@ from tools.musician import *
 from tools.RAG import *
 from tools.search import *
 
+# Skills promoted to tools
+from tools.oni_netmonitor import NetworkMonitor
+from tools.oni_portscanner import PortScanner
+from tools.oni_crypto_trade import TradingBot, TradingBotRNN
+
 __all__ = [
     'AIToolsRegistry',
     'ONICreativeAgent',
@@ -44,5 +49,9 @@ __all__ = [
     'AfterEffectsController',
     'PhotoshopController',
     'Calculator',
-    'FilePreprocessor'
+    'FilePreprocessor',
+    'NetworkMonitor',
+    'PortScanner',
+    'TradingBot',
+    'TradingBotRNN',
 ]

--- a/tools/oni_crypto_trade.py
+++ b/tools/oni_crypto_trade.py
@@ -1,0 +1,92 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import numpy as np
+import ccxt
+import time
+
+class TradingBotRNN(nn.Module):
+    def __init__(self, input_size, hidden_size, output_size):
+        super(TradingBotRNN, self).__init__()
+        self.hidden_size = hidden_size
+        self.rnn = nn.RNN(input_size, hidden_size, batch_first=True)
+        self.fc = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x, hidden):
+        out, hidden = self.rnn(x, hidden)
+        out = self.fc(out[:, -1, :])
+        return out, hidden
+
+    def init_hidden(self, batch_size):
+        return torch.zeros(1, batch_size, self.hidden_size)
+
+class TradingBot:
+    def __init__(self, api_key, secret, hidden_size=32, learning_rate=0.001):
+        # Exchange setup
+        self.exchange = ccxt.phemex({
+            'apiKey': api_key,
+            'secret': secret,
+        })
+        self.hidden_size = hidden_size
+        self.model = TradingBotRNN(input_size=5, hidden_size=hidden_size, output_size=1)
+        self.criterion = nn.MSELoss()
+        self.optimizer = optim.Adam(self.model.parameters(), lr=learning_rate)
+
+    def get_market_data(self, symbol, limit=100):
+        # Fetch OHLCV data
+        bars = self.exchange.fetch_ohlcv(symbol, timeframe='1m', limit=limit)
+        data = np.array(bars)
+        return data
+
+    def select_coin(self, coin):
+        if coin == 'BTC':
+            return 'uBTCUSD'
+        else:
+            return f'{coin}USD'
+
+    def train_model(self, symbol, epochs=10):
+        for epoch in range(epochs):
+            data = self.get_market_data(symbol)
+            x_train = torch.tensor(data[:, 1:6], dtype=torch.float32).unsqueeze(0)
+            y_train = torch.tensor(data[:, 4], dtype=torch.float32).unsqueeze(0)
+
+            hidden = self.model.init_hidden(x_train.size(0))
+            self.optimizer.zero_grad()
+            output, _ = self.model(x_train, hidden)
+            loss = self.criterion(output, y_train[:, -1].unsqueeze(1))
+            loss.backward()
+            self.optimizer.step()
+
+            print(f"Epoch {epoch+1}/{epochs}, Loss: {loss.item()}")
+
+    def make_trade_decision(self, symbol):
+        data = self.get_market_data(symbol, limit=20)
+        x_input = torch.tensor(data[:, 1:6], dtype=torch.float32).unsqueeze(0)
+        hidden = self.model.init_hidden(x_input.size(0))
+        output, _ = self.model(x_input, hidden)
+        decision = output.item()
+
+        if decision > 0:
+            self.place_order(symbol, 'buy', 1)
+        else:
+            self.place_order(symbol, 'sell', 1)
+
+    def place_order(self, symbol, side, amount):
+        try:
+            order = self.exchange.create_order(
+                symbol=symbol,
+                type='market',
+                side=side,
+                amount=amount
+            )
+            print(f"Order placed: {side} {amount} {symbol}")
+        except Exception as e:
+            print(f"Error placing order: {e}")
+
+    def run(self, coin, interval=60):
+        symbol = self.select_coin(coin)
+        while True:
+            self.make_trade_decision(symbol)
+            time.sleep(interval)
+
+trader = TradingBot

--- a/tools/oni_netmonitor.py
+++ b/tools/oni_netmonitor.py
@@ -1,0 +1,74 @@
+import psutil
+import time
+
+class NetworkMonitor:
+    def __init__(self, interval=1):
+        """
+        Initialize the network monitor.
+
+        Args:
+            interval (int): Time interval (in seconds) between network usage updates.
+        """
+        self.interval = interval
+        self.last_received = 0
+        self.last_sent = 0
+        self.running = False
+
+    def start(self):
+        """
+        Start monitoring network usage.
+        """
+        self.running = True
+        self.last_received, self.last_sent = self.get_current_stats()
+        print(f"Monitoring started. Interval: {self.interval} second(s).\n")
+        while self.running:
+            time.sleep(self.interval)
+            self.display_network_usage()
+
+    def stop(self):
+        """
+        Stop monitoring network usage.
+        """
+        self.running = False
+        print("\nMonitoring stopped.")
+
+    def get_current_stats(self):
+        """
+        Get the current network statistics (bytes sent and received).
+
+        Returns:
+            tuple: (bytes_received, bytes_sent)
+        """
+        net_io = psutil.net_io_counters()
+        return net_io.bytes_recv, net_io.bytes_sent
+
+    def display_network_usage(self):
+        """
+        Calculate and display the current network usage.
+        """
+        current_received, current_sent = self.get_current_stats()
+        received_diff = current_received - self.last_received
+        sent_diff = current_sent - self.last_sent
+
+        print(f"Received: {self.convert_bytes(received_diff)} | Sent: {self.convert_bytes(sent_diff)}")
+
+        # Update for the next interval
+        self.last_received = current_received
+        self.last_sent = current_sent
+
+    def convert_bytes(self, num):
+        """
+        Convert bytes to a human-readable format (KB, MB, etc.).
+
+        Args:
+            num (int): Number of bytes.
+
+        Returns:
+            str: Human-readable string representation of bytes.
+        """
+        for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+            if num < 1024.0:
+                return f"{num:.2f} {unit}"
+            num /= 1024.0
+
+netmon = NetworkMonitor

--- a/tools/oni_portscanner.py
+++ b/tools/oni_portscanner.py
@@ -1,0 +1,35 @@
+import socket
+import threading
+
+class PortScanner:
+    def __init__(self, target, start_port, end_port):
+        self.target = target
+        self.start_port = start_port
+        self.end_port = end_port
+
+    def scan_port(self, port):
+        scanner = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        scanner.settimeout(1)  # Timeout for the connection attempt
+        try:
+            scanner.connect((self.target, port))
+            print(f'[+] Port {port} is open')
+        except:
+            pass  # Ignore closed ports
+        finally:
+            scanner.close()
+
+    def start_scan(self):
+        print(f'Starting scan on {self.target} from port {self.start_port} to {self.end_port}...')
+        for port in range(self.start_port, self.end_port + 1):
+            thread = threading.Thread(target=self.scan_port, args=(port,))
+            thread.start()
+
+    def run(self):
+        target = input("Enter the target IP address: ")
+        start_port = int(input("Enter the starting port: "))
+        end_port = int(input("Enter the ending port: "))
+
+        scanner = PortScanner(target, start_port, end_port)
+        scanner.start_scan()
+
+ps = PortScanner


### PR DESCRIPTION
## Summary
This PR refactors the ONI.py import structure by removing extensive try-except fallback patterns and replacing them with direct imports, while adding new attention and trading modules. The changes improve code clarity and maintainability by assuming all core dependencies are available.

## Key Changes

- **Removed 200+ lines of fallback implementations**: Eliminated try-except blocks for ~20 modules (vision, audio, attention, memory, NLP, emotions, etc.) that were creating stub classes when imports failed. These are now imported directly with the assumption they exist.

- **Reorganized imports into semantic groups**: Grouped imports into three clear sections:
  - Core modules (paths confirmed)
  - External LLM/vision models (large optional downloads with graceful degradation)
  - Module-level singletons (calculator, tokenizer, trader)

- **Added new modules**:
  - `LatentResidualBlock` (modules/attention/latent_residual_block.py): Transformer-style block combining LatentAttention, ResidualAttention, MemoryAugmentedAttention, and FFN with orthogonal layer scales
  - `TradingBot` (tools/oni_crypto_trade.py): RNN-based trading bot with CCXT exchange integration
  - `NetworkMonitor` (tools/oni_netmonitor.py): Network usage monitoring utility
  - `PortScanner` (tools/oni_portscanner.py): Multi-threaded port scanning utility

- **Promoted skills to tools**: Moved network monitoring, port scanning, and trading functionality from modules/skills to tools directory and updated __init__.py exports

- **Simplified external model loading**: Kept only two try-except blocks for transformers (Qwen and Phi-3.5-vision) which are large optional downloads, with cleaner error handling

- **Removed redundant imports**: Cleaned up duplicate imports and removed unused `import json` statement

## Implementation Details

The LatentResidualBlock introduces a multi-path attention architecture with:
- Perceiver-style bottleneck (LatentAttention) for global context compression/expansion
- Causal self-attention with KV-cache support (ResidualAttention) for local precision
- Optional persistent memory augmentation (MemoryAugmentedAttention)
- Independent learnable gamma scales per path for orthogonal layer contributions

This change assumes all core ONI modules are properly installed and available, improving code readability while maintaining graceful degradation only for large external models.

https://claude.ai/code/session_01NSevvJysU8AyaNMepWco9X